### PR TITLE
update file icon, check file is remote first

### DIFF
--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -337,10 +337,10 @@ See `ivy-rich-display-transformers-list' for details."
   (let* ((path (concat ivy--directory candidate))
          (file (file-name-nondirectory path))
          (icon (cond
+                ((file-remote-p path)
+                 (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
                 ((file-directory-p path)
                  (all-the-icons-icon-for-dir path nil ""))
-                ((string-match "^/.*:$" path)
-                 (all-the-icons-octicon "radio-tower" :height 1.0 :v-adjust 0.01))
                 ((not (string-empty-p file))
                  (all-the-icons-icon-for-file file :v-adjust -0.05)))))
     (all-the-icons-ivy-rich--format-icon


### PR DESCRIPTION
Checking a file  is remote or not should be placed before `file-directory-p`, because `(file-directory-p "/sudo:root@localhost:/etc/hosts")` always ask password with `counsel-find-file` or `counsel-recentf`