### PR TITLE
Add display-transformer for mediator-open-with

### DIFF
--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -479,6 +479,12 @@ It respects `all-the-icons-color-icons'."
       (ivy-rich-switch-buffer-project (:width 0.12 :face all-the-icons-ivy-rich-project-face))
       (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
      :delimiter "\t")
+    
+    mediator-open-with
+    (:columns
+     ((all-the-icons-ivy-rich-app-icon)
+      (ivy-rich-candidate))
+     :delimiter "\t")
 
     treemacs-projectile
     (:columns


### PR DESCRIPTION
I have just now written a simple package called mediator (see [here](https://github.com/dalanicolai/mediator)) that uses xdg mime type information to present a list of fitting applications for external opening a file (on GNU/linux).
The functionality can be used as an Ivy or Embark (etc.) action. It also support icons in Ivy using this package, but for that, currently, the user has to add the right definition to the display-transformers list. It would be nice if this can be added to the list by default, hence this PR.

I also have a small question. The icons only show when invoking the `mediator-open-with` command directly, so not when invoked as an Embark or Ivy action (although for Embark I defined the `embark-open-with` function, which has no display-transformer definition). Do you know how to get the icons also when invoking the command as an Ivy action? Thank you...