### PR TITLE
Use only the file name when searching for icons

### DIFF
--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -1003,7 +1003,7 @@ If the buffer is killed, return \"--\"."
                                             :v-adjust 0.01
                                             :face 'all-the-icons-ivy-rich-dir-face))
                ((not (string-empty-p candidate))
-                (all-the-icons-icon-for-file candidate :height 0.9 :v-adjust 0.0)))))
+                (all-the-icons-icon-for-file (file-name-nondirectory candidate) :height 0.9 :v-adjust 0.0)))))
     (all-the-icons-ivy-rich--format-icon
      (if (or (null icon) (symbolp icon))
          (all-the-icons-faicon "file-o" :face 'all-the-icons-dsilver :height 0.9 :v-adjust 0.0)


### PR DESCRIPTION
Unlike `counsel-find-file`, the list of candidates produced by `counsel-fzf` is a list of relative paths, not filenames. As `all-the-icons-ivy-rich-file-icon` is used in both cases, I think it makes sense to always pass only filenames to `all-the-icons-icon-for-file`.

This patch applies `file-name-nondirectory` to the candidates to achieve that goal.

The main reason for this is to make it work nicely with https://github.com/domtronn/all-the-icons.el/pull/300.

With the patch for `all-the-icons` above applied, `counsel-fzf`'s candidates like `.github/foo.md` will erroneously get [this icon](https://github.com/domtronn/all-the-icons.el/blob/master/all-the-icons.el#L477) applied, instead of [this other one](https://github.com/domtronn/all-the-icons.el/blob/master/all-the-icons.el#L382).

Feel free to ignore this, I guess I can always redefine the function in my config.