### PR TITLE
Use project-root to get project.el root

### DIFF
--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -991,7 +991,9 @@ Return `default-directory' if no project was found."
       (projectile-project-root))
      ((fboundp 'project-current)
       (when-let ((project (project-current)))
-        (expand-file-name (project-root project))))
+        (expand-file-name (if (fboundp 'project-root)
+                              (project-root project)
+                            (cdr project)))))
      (t default-directory))))
 
 (defun all-the-icons-ivy-rich--file-path (cand)
@@ -1006,7 +1008,9 @@ Return `default-directory' if no project was found."
 
 (defun all-the-icons-ivy-rich-project-find-file-transformer (cand)
   "Transform non-visited file names with `ivy-virtual' face."
-  (if (not (get-file-buffer (expand-file-name cand (project-root (project-current)))))
+  (if (not (get-file-buffer (expand-file-name cand (if (fboundp 'project-root)
+                                                       (project-root (project-current))
+                                                     (cdr (project-current))))))
       (propertize cand 'face 'ivy-virtual)
     cand))
 

--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -989,9 +989,9 @@ Return `default-directory' if no project was found."
         (ffip-get-project-root-directory)))
      ((fboundp 'projectile-project-root)
       (projectile-project-root))
-     ((fboundp 'project-current)
+     ((and (fboundp 'project-current) (fboundp 'project-root))
       (when-let ((project (project-current)))
-        (expand-file-name (cdr project))))
+        (expand-file-name (project-root project))))
      (t default-directory))))
 
 (defun all-the-icons-ivy-rich--file-path (cand)
@@ -1006,7 +1006,7 @@ Return `default-directory' if no project was found."
 
 (defun all-the-icons-ivy-rich-project-find-file-transformer (cand)
   "Transform non-visited file names with `ivy-virtual' face."
-  (if (not (get-file-buffer (expand-file-name cand (cdr (project-current)))))
+  (if (not (get-file-buffer (expand-file-name cand (project-root (project-current)))))
       (propertize cand 'face 'ivy-virtual)
     cand))
 

--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -989,7 +989,7 @@ Return `default-directory' if no project was found."
         (ffip-get-project-root-directory)))
      ((fboundp 'projectile-project-root)
       (projectile-project-root))
-     ((and (fboundp 'project-current) (fboundp 'project-root))
+     ((fboundp 'project-current)
       (when-let ((project (project-current)))
         (expand-file-name (project-root project))))
      (t default-directory))))


### PR DESCRIPTION
As of https://github.com/emacs-mirror/emacs/commit/86969f9658e278ebacb3d625d0309046ff1f2b54, `project-current` returns a list rather than a cons cell, so when building Emacs from master (and therefore in versions 29 and forward), `(cdr (project-current))` will not return a string as the other code here expects.

Luckily, `project-root` already exists and handles both cases, so using it here is both backward- and forward-compatible.