### PR TITLE
Use ivy-grep-info face instead of compilation-info

### DIFF
--- a/all-the-icons-ivy-rich.el
+++ b/all-the-icons-ivy-rich.el
@@ -1601,15 +1601,15 @@ Support`counsel-ack', `counsel-ag', `counsel-pt' and `counsel-rg', etc."
           (line (match-string 2 cand))
           (result (match-string 3 cand)))
       (format "%s:%s:%s"
-              (propertize file 'face 'compilation-info)
-              (propertize line 'face 'compilation-info)
+              (propertize file 'face 'ivy-grep-info)
+              (propertize line 'face 'ivy-grep-info)
               result)))
    ((string-match "\\(.+\\):\\(.+\\)(\\(.+\\))" cand)
     (let ((file (match-string 1 cand))
           (msg (match-string 2 cand))
           (err (match-string 3 cand)))
       (format "%s:%s(%s)"
-              (propertize file 'face 'compilation-info)
+              (propertize file 'face 'ivy-grep-info)
               msg
               (propertize err 'face 'error))))
    (t cand)))


### PR DESCRIPTION
I noticed that using this mode broke my styling changes when using `cousel-rg`. This fixes it.

Ivy is using [ivy-grep-info](https://github.com/abo-abo/swiper/blob/master/ivy-faces.el#L120) to style search results.

Because it inherits from `compilation-info` this won't change any existing behaviour for people who are relying on that style for this mode.

```
(defface ivy-grep-info
  '((t :inherit compilation-info))
  "Face for highlighting grep information such as file names.")
```